### PR TITLE
set cache to 1 month

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,6 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    minimumCacheTTL: 2678400,
     remotePatterns: [
       {
         protocol: "https",
@@ -29,6 +28,15 @@ const nextConfig = {
   },
   async headers() {
     return [
+      {
+        source: "/_next/image?url=https%3A%2F%2Ffirebasestorage.googleapis.com%2Fv0%2Fb%2Fgdg-website-314a4.firebasestorage.app%2Fo%2Fusers(.*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=2678400, s-maxage=2678400, immutable",
+          },
+        ],
+      },
       {
         source: "/(.*)",
         headers: [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
+    minimumCacheTTL: 2678400,
     remotePatterns: [
       {
         protocol: "https",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
+    minimumCacheTTL: 2592000,
     remotePatterns: [
       {
         protocol: "https",
@@ -28,15 +29,6 @@ const nextConfig = {
   },
   async headers() {
     return [
-      {
-        source: "/_next/image?url=https%3A%2F%2Ffirebasestorage.googleapis.com%2Fv0%2Fb%2Fgdg-website-314a4.firebasestorage.app%2Fo%2Fusers(.*)",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=2678400, s-maxage=2678400, immutable",
-          },
-        ],
-      },
       {
         source: "/(.*)",
         headers: [

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { getAuthenticatedUser } from "@/lib/firebase/server/index";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function middleware(request: NextRequest) {
-  if (!request.nextUrl.pathname.startsWith("/admin")) {
+  if (!request.nextUrl.pathname.startsWith("/admin") && !request.nextUrl.pathname.startsWith("/api/admin")) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Increased image caching TTL so optimized images are retained for ~30 days, improving repeat-load performance and reducing bandwidth and cache misses.

- Bug Fixes
  - Broadened admin bypass so both admin pages and admin API endpoints skip redundant checks, improving access flow and reducing unnecessary redirects for admin users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->